### PR TITLE
you need to require 'optparse' if you use OptionParser

### DIFF
--- a/lib/activehook/app/launcher.rb
+++ b/lib/activehook/app/launcher.rb
@@ -1,3 +1,5 @@
+require 'optparse'
+
 module ActiveHook
   module App
     # Handles the start of the ActiveHook web via command line

--- a/lib/activehook/server/launcher.rb
+++ b/lib/activehook/server/launcher.rb
@@ -1,3 +1,5 @@
+require 'optparse'
+
 module ActiveHook
   module Server
     # Handles the start of the ActiveHook server via command line


### PR DESCRIPTION
Without this patch I get:

```
$ bundle exec activehook-server -c config/activehook.rb 
[ OK ] ActiveHook Server starting!
[ OK ] * Version 0.1.9, codename: Fat Sparrow
.../vendor/bundle/ruby/2.3.0/gems/activehook-0.1.9/lib/activehook/server/launcher.rb:28:in `setup_options': uninitialized constant ActiveHook::Server::Launcher::OptionParser (NameError)
        from .../vendor/bundle/ruby/2.3.0/gems/activehook-0.1.9/lib/activehook/server/launcher.rb:14:in `start'
        from .../vendor/bundle/ruby/2.3.0/gems/activehook-0.1.9/bin/activehook-server:7:in `<top (required)>'
        from .../vendor/bundle/ruby/2.3.0/bin/activehook-server:23:in `load'
        from .../vendor/bundle/ruby/2.3.0/bin/activehook-server:23:in `<main>'
        from /home/panzi/.rvm/gems/ruby-2.3.3@global/bin/ruby_executable_hooks:15:in `eval'
        from /home/panzi/.rvm/gems/ruby-2.3.3@global/bin/ruby_executable_hooks:15:in `<main>'
```